### PR TITLE
bump pytest version from 3.3.0 to 3.5.0 to get past broken attrs issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 *.iml
 
 __pycache__
+.pytest_cache*
 .cache
 .coverage
 
 .DS_Store
+
+_virtualenv

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 codecov == 2.0.9
 mock == 2.0.0
-pytest == 3.3.0
+pytest == 3.5.0
 pytest-asyncio == 0.8.0
 pytest-cov == 2.5.1
 pytest-mock == 1.6.3


### PR DESCRIPTION
I was following the [developer-guide on testing my keeper.](https://github.com/makerdao/developerguides/blob/master/keepers/auction-keeper-bot-setup-guide.md#6-testing-your-keeper)

I ran into the following error:
```
[....]/makerdao/auction-keeper/_virtualenv/lib/python3.7/site-packages/_pytest/fixtures.py", line 841, in FixtureFunctionMarker
    params = attr.ib(convert=attr.converters.optional(tuple))
TypeError: attrib() got an unexpected keyword argument 'convert'
```
full output: https://gist.github.com/savil/ca0ff4c5db048fa5981b949fd8cd949b

Googling the error message reveals that this was a common issue faced by older pytest versions. Looking at the [pytest changelog](https://docs.pytest.org/en/latest/changelog.html), it seems like version 3.5.0 fixes the issues with the `attrs` library, so i tried bumping to that version (3.5.0). 


Test Plan:
I ran:
```
./test.sh
```

and was able to continue past the previous failure.  I did still run into some other issues with failing tests, but i suspect these are unrelated. Output from `./test.sh`: https://gist.github.com/savil/ca8df6a4d8910b4d228da54f3fa123f3.