### PR TITLE
Spend less time checking active auctions

### DIFF
--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -255,7 +255,7 @@ class AuctionKeeper:
 
                 self._run_future(self.cat.bite(ilk, current_urn).transact_async())
 
-        self.logger.debug(f"Checked {len(urns)} urns in {(datetime.now()-started).seconds} seconds")
+        self.logger.debug(f"Checked {len(last_note_event)} urns in {(datetime.now()-started).seconds} seconds")
         # Cat.bite implicitly kicks off the flip auction; no further action needed.
 
     def check_flap(self):


### PR DESCRIPTION
Assume any auction with end time of 0 is dead and no longer needs to be checked.  This doesn't help with a corner case where someone calls `tick` on a `deal`t auction, resulting in `end` being set to a nonzero value (as in mainnet ETH-A auction 15).

Also:
- Handle more node disconnection use cases
- Log time consumed checking CDPs and auctions for debugging purposes