### PR TITLE
Cleaned up unit tests

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,8 @@ popd
 
 PYTHONPATH=$PYTHONPATH:./lib/pymaker:./lib/ethgasstation-client py.test \
   --cov=auction_keeper --cov-report=term --cov-append \
-  --log-format="%(asctime)s %(levelname)s %(message)s" --log-date-format="%H:%M:%S" tests/ $@
+  --log-format="%(asctime)s %(levelname)s %(message)s" --log-date-format="%H:%M:%S" \
+  tests/ $@
 TEST_RESULT=$?
 
 echo Stopping container

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -105,7 +105,7 @@ class TransactionIgnoringTest:
         self.web3.manager.request_blocking = MagicMock(side_effect=mock_web3manager_request_blocking)
         logging.debug(f"Started ignoring async transactions at nonce {self.original_nonce}")
 
-    def end_ignoring_transactions(self, cancel=True):
+    def end_ignoring_transactions(self):
         def second_send_transaction(transaction):
             print(f"tx_nonce={transaction['nonce']} original_nonce={self.original_nonce}")
             assert transaction['nonce'] == self.original_nonce

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -75,12 +75,6 @@ class TransactionIgnoringTest:
             })
             self.successful = True
 
-    def cancel(self, tx: Transact):
-        assert isinstance(tx, Transact)
-        logging.debug(f"Cancelling transaction {tx}")
-        empty_tx = Transact(self, self.web3, None, self.keeper_address, None, None, [self.keeper_address, Wad(0)])
-        empty_tx.transact(replace=tx)
-
     def start_ignoring_transactions(self):
         """ Allows an async tx to be created and leaves it trapped in Transact's event loop """
         self.original_send_transaction = self.web3.eth.sendTransaction

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -23,7 +23,11 @@ import time
 from contextlib import contextmanager
 from io import StringIO
 from mock import MagicMock
+from pymaker import Wad
 from web3 import Web3
+
+
+from pymaker import Receipt, Transact
 
 
 def args(arguments: str) -> list:
@@ -62,25 +66,77 @@ def wait_for_other_threads():
 
 
 class TransactionIgnoringTest:
+    class MockReceipt(Receipt):
+        def __init__(self):
+            super().__init__({
+                'transactionHash': '0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd',
+                'gasUsed': 12345,
+                'logs': []
+            })
+            self.successful = True
+
+    def cancel(self, tx: Transact):
+        assert isinstance(tx, Transact)
+        print(f"cancelling transaction {tx}")
+        empty_tx = Transact(self, self.web3, None, self.keeper_address, None, None, [self.keeper_address, Wad(0)])
+        empty_tx.transact(replace=tx)
+
     def start_ignoring_transactions(self):
+        def mock_web3manager_request_blocking(method: str, params: list):
+            print(f"mock_web3manager_request_blocking called for method={method}")
+            if method == "parity_nextNonce":
+                print("mocking parity_nextNonce")
+                return hex(self.original_nonce)
+            else:
+                return self.original_request_blocking(method, params)
+
+        assert self.web3
+
+        """ Allows an async tx to be created and leaves it trapped in Transact's event loop """
         self.original_send_transaction = self.web3.eth.sendTransaction
         self.original_get_transaction = self.web3.eth.getTransaction
+        self.original_tx_count = self.web3.eth.getTransactionCount
         self.original_nonce = self.web3.eth.getTransactionCount(self.keeper_address.address)
+        self.original_request_blocking = self.web3.manager.request_blocking
 
         self.web3.eth.sendTransaction = MagicMock(return_value='0xaaaaaaaaaabbbbbbbbbbccccccccccdddddddddd')
         self.web3.eth.getTransaction = MagicMock(return_value={'nonce': self.original_nonce})
-        logging.debug("Started ignoring transactions")
+        self.web3.eth.getTransactionCount = MagicMock(return_value=8888888888)
+        self.web3.manager.request_blocking = MagicMock(side_effect=mock_web3manager_request_blocking)
+        logging.debug(f"Started ignoring async transactions at nonce {self.original_nonce}")
 
-    def end_ignoring_transactions(self):
-        # def second_send_transaction(transaction):
-        #     assert transaction['nonce'] == self.original_nonce
-        #
-        #     # TestRPC doesn't support `sendTransaction` calls with the `nonce` parameter
-        #     # (unlike proper Ethereum nodes which handle it very well)
-        #     transaction_without_nonce = {key: transaction[key] for key in transaction if key != 'nonce'}
-        #     return self.original_send_transaction(transaction_without_nonce)
-        #
+    def end_ignoring_transactions(self, cancel=True):
+        def second_send_transaction(transaction):
+            print(f"tx_nonce={transaction['nonce']} original_nonce={self.original_nonce}")
+            assert transaction['nonce'] == self.original_nonce
+
+            # TestRPC doesn't support `sendTransaction` calls with the `nonce` parameter
+            # (unlike proper Ethereum nodes which handle it very well)
+            transaction_without_nonce = {key: transaction[key] for key in transaction if key != 'nonce'}
+            return self.original_send_transaction(transaction_without_nonce)
+
         # self.web3.eth.sendTransaction = MagicMock(side_effect=second_send_transaction)
         self.web3.eth.sendTransaction = self.original_send_transaction
         self.web3.eth.getTransaction = self.original_get_transaction
-        logging.debug("Finished ignoring transactions")
+        self.web3.eth.getTransactionCount = self.original_tx_count
+        self.web3.manager.request_blocking = self.original_request_blocking
+        logging.debug("Finished ignoring async transactions")
+
+    def start_ignoring_sync_transactions(self):
+        assert self.web3
+
+        """ Mocks submission of a tx, prentending it happened """
+        self.original_tx_count = self.web3.eth.getTransactionCount
+        self.original_get_receipt = Transact._get_receipt
+        self.original_func = Transact._func
+
+        Transact._get_receipt = MagicMock(return_value=TransactionIgnoringTest.MockReceipt())
+        Transact._func = MagicMock(return_value='0xccccccccccddddddddddaaaaaaaaaabbbbbbbbbb')
+        self.web3.eth.getTransactionCount = MagicMock(return_value=9999999999)
+        logging.debug("Started ignoring sync transactions")
+
+    def end_ignoring_sync_transactions(self):
+        self.web3.eth.getTransactionCount = self.original_tx_count
+        Transact._get_receipt = self.original_get_receipt
+        Transact._func = self.original_func
+        logging.debug("Finished ignoring sync transactions")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,27 +59,6 @@ class TestTransactionMocking(TransactionIgnoringTest):
         self.check_sync_transaction_still_works()
         self.check_async_transaction_still_works()
 
-    @pytest.mark.skip("not core use case")
-    @pytest.mark.timeout(30)
-    def test_ignore_async_transaction(self):
-        balance_before = self.mcd.vat.gem(self.ilk, self.keeper_address)
-
-        self.start_ignoring_transactions()
-        amount = Wad.from_number(0.2)
-        tx = self.collateral.adapter.join(self.keeper_address, amount)
-        AuctionKeeper._run_future(tx.transact_async())
-        self.cancel(tx)
-        self.end_ignoring_transactions(ensure_next_tx_is_replacement=False)
-
-        # Wait for async tx threads to exit normally (should consider doing this after every async test)
-        wait_for_other_threads()
-
-        balance_after = self.mcd.vat.gem(self.ilk, self.keeper_address)
-        assert balance_before == balance_after
-
-        self.check_sync_transaction_still_works()
-        self.check_async_transaction_still_works()
-
     @pytest.mark.timeout(30)
     def test_replace_async_transaction(self):
         balance_before = self.mcd.vat.gem(self.ilk, self.keeper_address)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,8 +59,8 @@ class TestTransactionMocking(TransactionIgnoringTest):
         self.check_sync_transaction_still_works()
         self.check_async_transaction_still_works()
 
-    @pytest.mark.skip("not what we're really trying to test")
-    @pytest.mark.timeout(15)
+    @pytest.mark.skip("not core use case")
+    @pytest.mark.timeout(30)
     def test_ignore_async_transaction(self):
         balance_before = self.mcd.vat.gem(self.ilk, self.keeper_address)
 
@@ -69,7 +69,7 @@ class TestTransactionMocking(TransactionIgnoringTest):
         tx = self.collateral.adapter.join(self.keeper_address, amount)
         AuctionKeeper._run_future(tx.transact_async())
         self.cancel(tx)
-        self.end_ignoring_transactions()
+        self.end_ignoring_transactions(ensure_next_tx_is_replacement=False)
 
         # Wait for async tx threads to exit normally (should consider doing this after every async test)
         wait_for_other_threads()
@@ -98,6 +98,9 @@ class TestTransactionMocking(TransactionIgnoringTest):
         wait_for_other_threads()
         balance_after = self.mcd.vat.gem(self.ilk, self.keeper_address)
         assert balance_before + amount2 == balance_after
+
+        self.check_sync_transaction_still_works()
+        self.check_async_transaction_still_works()
 
     def check_sync_transaction_still_works(self):
         balance_before = self.mcd.vat.gem(self.ilk, self.keeper_address)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,7 @@ class TestTransactionMocking(TransactionIgnoringTest):
         empty_tx = Transact(self, self.web3, None, self.keeper_address, None, None, [self.keeper_address, Wad(0)])
         empty_tx.transact()
 
-    @pytest.mark.timeout(6)
+    @pytest.mark.timeout(15)
     def test_ignore_sync_transaction(self):
         balance_before = self.mcd.vat.gem(self.ilk, self.keeper_address)
 
@@ -57,8 +57,7 @@ class TestTransactionMocking(TransactionIgnoringTest):
         self.check_sync_transaction_still_works()
         self.check_async_transaction_still_works()
 
-    @pytest.mark.skip("the ignored tx gets trapped in Transact's event loop")
-    @pytest.mark.timeout(6)
+    @pytest.mark.timeout(15)
     def test_ignore_async_transaction(self):
         balance_before = self.mcd.vat.gem(self.ilk, self.keeper_address)
 
@@ -66,9 +65,11 @@ class TestTransactionMocking(TransactionIgnoringTest):
         amount = Wad.from_number(0.2)
         tx = self.collateral.adapter.join(self.keeper_address, amount)
         AuctionKeeper._run_future(tx.transact_async())
-        wait_for_other_threads()
         self.cancel(tx)
         self.end_ignoring_transactions()
+
+        # Wait for async tx threads to exit normally (should consider doing this after every async test)
+        wait_for_other_threads()
 
         balance_after = self.mcd.vat.gem(self.ilk, self.keeper_address)
         assert balance_before == balance_after

--- a/tests/test_flap.py
+++ b/tests/test_flap.py
@@ -17,7 +17,6 @@
 
 import math
 import pytest
-import time
 
 from auction_keeper.main import AuctionKeeper
 from auction_keeper.model import Parameters
@@ -44,7 +43,7 @@ def kick(mcd, c: Collateral, gal_address) -> int:
     return kick
 
 
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(380)
 class TestAuctionKeeperFlapper(TransactionIgnoringTest):
     def setup_method(self):
         self.web3 = web3()
@@ -360,7 +359,6 @@ class TestAuctionKeeperFlapper(TransactionIgnoringTest):
         time_travel_by(self.web3, self.flapper.ttl() + 1)
         assert self.flapper.deal(kick).transact()
 
-    @pytest.mark.skip("Timing issue causes this to fail on Travis and under CPU pressure")
     def test_should_increase_gas_price_of_pending_transactions_if_model_increases_gas_price(self, kick):
         # given
         (model, model_factory) = models(self.keeper, kick)
@@ -401,8 +399,6 @@ class TestAuctionKeeperFlapper(TransactionIgnoringTest):
         self.keeper.check_all_auctions()
         self.keeper.check_for_bids()
         # and
-        time.sleep(2)
-        # and
         self.end_ignoring_transactions()
         # and
         simulate_model_output(model=model, price=Wad.from_number(8.0), gas_price=15)
@@ -431,7 +427,6 @@ class TestAuctionKeeperFlapper(TransactionIgnoringTest):
         self.keeper.check_for_bids()
         # and
         self.end_ignoring_transactions()
-        wait_for_other_threads()
         # and
         simulate_model_output(model=model, price=Wad.from_number(8.0), gas_price=15)
         # and

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import pytest
-import time
 
 from auction_keeper.main import AuctionKeeper
 from auction_keeper.model import Parameters
@@ -55,40 +54,22 @@ def kick_small_lot(mcd, c: Collateral, gal_address) -> int:
     return bite(mcd, c, unsafe_cdp)
 
 
-def create_keeper(mcd: DssDeployment, c: Collateral, address=None):
-    assert isinstance(mcd, DssDeployment)
-    assert isinstance(c, Collateral)
-    if address is None:
-        address = Address(mcd.web3.eth.accounts[1])
-    assert isinstance(address, Address)
-
-    keeper = AuctionKeeper(args=args(f"--eth-from {address} "
-                                     f"--type flip "
-                                     f"--from-block 1 "
-                                     f"--ilk {c.ilk.name} "
-                                     f"--bid-check-interval 0.03 "
-                                     f"--model ./bogus-model.sh"), web3=mcd.web3)
-    keeper.approve()
-    return keeper
-
-
-@pytest.fixture()
-def keeper(web3, c: Collateral, keeper_address: Address, mcd):
-    return create_keeper(mcd, c, keeper_address)
-
-
-@pytest.fixture()
-def other_keeper(web3, c: Collateral, other_address: Address, mcd):
-    return create_keeper(mcd, c, other_address)
-
-
 @pytest.mark.timeout(500)
 class TestAuctionKeeperFlipper(TransactionIgnoringTest):
     def setup_class(self):
         """ I'm excluding initialization of a specific collateral perchance we use multiple collaterals
         to improve test speeds.  This prevents us from instantiating the keeper as a class member. """
         self.web3 = web3()
+        self.mcd = mcd(self.web3)
         self.keeper_address = keeper_address(self.web3)
+        self.collateral = self.mcd.collaterals['ETH-B']
+        self.keeper = AuctionKeeper(args=args(f"--eth-from {self.keeper_address.address} "
+                                     f"--type flip "
+                                     f"--from-block 1 "
+                                     f"--ilk {self.collateral.ilk.name} "
+                                     f"--bid-check-interval 0.03 "
+                                     f"--model ./bogus-model.sh"), web3=self.mcd.web3)
+        self.keeper.approve()
 
     @staticmethod
     def gem_balance(address: Address, c: Collateral) -> Wad:
@@ -163,47 +144,49 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         reserve_dai(mcd, c, address, Wad(bid), extra_collateral=Wad.from_number(2))
         TestAuctionKeeperFlipper.tend(flipper, id, address, previous_bid.lot, bid)
 
-    def test_flipper_address(self, keeper, c):
+    def test_flipper_address(self):
         """ Sanity check ensures the keeper fixture is looking at the correct collateral """
-        assert keeper.flipper.address == c.flipper.address
+        assert self.keeper.flipper.address == self.collateral.flipper.address
 
-    def test_should_start_a_new_model_and_provide_it_with_info_on_auction_kick(self, c, kick, mcd, keeper):
+    def test_should_start_a_new_model_and_provide_it_with_info_on_auction_kick(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
+        (model, model_factory) = models(self.keeper, kick)
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
-        initial_bid = c.flipper.bids(kick)
+        initial_bid = self.collateral.flipper.bids(kick)
         # then
-        model_factory.create_model.assert_called_once_with(Parameters(flipper=c.flipper.address,
+        model_factory.create_model.assert_called_once_with(Parameters(flipper=self.collateral.flipper.address,
                                                                       flapper=None,
                                                                       flopper=None,
                                                                       id=kick))
         # and
         status = model.send_status.call_args[0][0]
         assert status.id == kick
-        assert status.flipper == c.flipper.address
+        assert status.flipper == self.collateral.flipper.address
         assert status.flapper is None
         assert status.flopper is None
         assert status.bid == Rad.from_number(0)
         assert status.lot == initial_bid.lot
         assert status.tab == initial_bid.tab
         assert status.beg > Wad.from_number(1)
-        assert status.guy == mcd.cat.address
+        assert status.guy == self.mcd.cat.address
         assert status.era > 0
-        assert status.end < status.era + c.flipper.tau() + 1
+        assert status.end < status.era + self.collateral.flipper.tau() + 1
         assert status.tic == 0
         assert status.price == Wad(0)
 
-    def test_should_provide_model_with_updated_info_after_our_own_bid(self, mcd, c, gal_address, keeper):
+        # cleanup
+        time_travel_by(self.web3, self.collateral.flipper.ttl() + 1)
+
+    def test_should_provide_model_with_updated_info_after_our_own_bid(self, kick):
         # given
-        flipper = c.flipper
-        kick = flipper.kicks()
-        (model, model_factory) = models(keeper, kick)
+        flipper = self.collateral.flipper
+        (model, model_factory) = models(self.keeper, kick)
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         previous_bid = flipper.bids(model.id)
         # then
@@ -213,15 +196,15 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         initial_bid = flipper.bids(kick)
         our_price = Wad.from_number(30)
         our_bid = our_price * initial_bid.lot
-        reserve_dai(mcd, c, self.keeper_address, our_bid)
+        reserve_dai(self.mcd, self.collateral, self.keeper_address, our_bid)
         simulate_model_output(model=model, price=our_price)
-        keeper.check_for_bids()
+        self.keeper.check_for_bids()
 
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         assert model.send_status.call_count > 1
@@ -245,13 +228,13 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_provide_model_with_updated_info_after_somebody_else_bids(self, mcd, c, kick, other_address, keeper):
+    def test_should_provide_model_with_updated_info_after_somebody_else_bids(self, kick, other_address):
         # given
-        flipper = c.flipper
-        (model, model_factory) = models(keeper, kick)
+        flipper = self.collateral.flipper
+        (model, model_factory) = models(self.keeper, kick)
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         assert model.send_status.call_count == 1
@@ -260,9 +243,9 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         flipper.approve(flipper.vat(), approval_function=hope_directly(from_address=other_address))
         previous_bid = flipper.bids(kick)
         new_bid_amount = Rad.from_number(80)
-        self.tend_with_dai(mcd, c, flipper, model.id, other_address, new_bid_amount)
+        self.tend_with_dai(self.mcd, self.collateral, flipper, model.id, other_address, new_bid_amount)
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         assert model.send_status.call_count > 1
@@ -282,14 +265,13 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         assert status.tic > status.era
         assert status.price == (Wad(new_bid_amount) / previous_bid.lot)
 
-    def test_should_terminate_model_if_auction_expired_due_to_tau(self, c, keeper):
+    def test_should_terminate_model_if_auction_expired_due_to_tau(self, kick):
         # given
-        flipper = c.flipper
-        kick = flipper.kicks()
-        (model, model_factory) = models(keeper, kick)
+        flipper = self.collateral.flipper
+        (model, model_factory) = models(self.keeper, kick)
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         model_factory.create_model.assert_called_once()
@@ -298,23 +280,19 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         # when
         time_travel_by(self.web3, flipper.tau() + 1)
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         model_factory.create_model.assert_called_once()
         model.terminate.assert_called_once()
 
-        # cleanup
-        assert flipper.deal(kick).transact()
-
-    def test_should_terminate_model_if_auction_expired_due_to_ttl_and_somebody_else_won_it(self, mcd, c, kick,
-                                                                                           other_address, keeper):
+    def test_should_terminate_model_if_auction_expired_due_to_ttl_and_somebody_else_won_it(self, kick, other_address):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         model_factory.create_model.assert_called_once()
@@ -323,11 +301,11 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         # when
         flipper.approve(flipper.vat(), approval_function=hope_directly(from_address=other_address))
         new_bid_amount = Rad.from_number(85)
-        self.tend_with_dai(mcd, c, flipper, kick, other_address, new_bid_amount)
+        self.tend_with_dai(self.mcd, self.collateral, flipper, kick, other_address, new_bid_amount)
         # and
         time_travel_by(self.web3, flipper.ttl() + 1)
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         model_factory.create_model.assert_called_once()
@@ -336,70 +314,71 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         # cleanup
         assert flipper.deal(kick).transact()
 
-    def test_should_terminate_model_if_auction_is_dealt(self, mcd, c, kick, other_address, keeper):
+    def test_should_terminate_model_if_auction_is_dealt(self, kick, other_address):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         model_factory.create_model.assert_called_once()
         model.terminate.assert_not_called()
 
         # when
-        self.tend_with_dai(mcd, c, flipper, kick, other_address, Rad.from_number(90))
+        self.tend_with_dai(self.mcd, self.collateral, flipper, kick, other_address, Rad.from_number(90))
         # and
         time_travel_by(self.web3, flipper.ttl() + 1)
         # and
         flipper.deal(kick).transact(from_address=other_address)
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         model_factory.create_model.assert_called_once()
         model.terminate.assert_called_once()
 
-    def test_should_not_instantiate_model_if_auction_is_dealt(self, mcd, c, kick, other_address, keeper):
+    def test_should_not_instantiate_model_if_auction_is_dealt(self, kick, other_address):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
         # and
-        TestAuctionKeeperFlipper.tend_with_dai(mcd, c, flipper, kick, other_address, Rad.from_number(90))
+        TestAuctionKeeperFlipper.tend_with_dai(self.mcd, self.collateral, flipper, kick, other_address,
+                                               Rad.from_number(90))
         # and
         time_travel_by(self.web3, flipper.ttl() + 1)
         # and
         flipper.deal(kick).transact(from_address=other_address)
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         model_factory.create_model.assert_not_called()
 
-    def test_should_not_do_anything_if_no_output_from_model(self, keeper):
+    def test_should_not_do_anything_if_no_output_from_model(self):
         # given
         previous_block_number = self.web3.eth.blockNumber
 
         # when
         # [no output from model]
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         assert self.web3.eth.blockNumber == previous_block_number
 
-    def test_should_make_initial_bid(self, mcd, c, kick, keeper, keeper_address):
+    def test_should_make_initial_bid(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
-        self.simulate_model_bid(mcd, c, model, Wad.from_number(16.0))
+        self.simulate_model_bid(self.mcd, self.collateral, model, Wad.from_number(16.0))
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -409,38 +388,37 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_bid_even_if_there_is_already_a_bidder(self, mcd, c, kick, keeper, keeper_address, other_address):
+    def test_should_bid_even_if_there_is_already_a_bidder(self, kick, other_address):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
         # and
-        self.tend_with_dai(mcd, c, flipper, kick, other_address, Rad.from_number(21))
+        self.tend_with_dai(self.mcd, self.collateral, flipper, kick, other_address, Rad.from_number(21))
         assert flipper.bids(kick).bid == Rad.from_number(21)
 
         # when
-        self.simulate_model_bid(mcd, c, model, Wad.from_number(23))
+        self.simulate_model_bid(self.mcd, self.collateral, model, Wad.from_number(23))
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
         assert round(auction.bid / Rad(auction.lot), 2) == round(Rad.from_number(23), 2)
 
-    def test_should_sequentially_tend_and_dent_if_price_takes_us_to_the_dent_phrase(self, mcd, c, kick, keeper,
-                                                                                    keeper_address):
+    def test_should_sequentially_tend_and_dent_if_price_takes_us_to_the_dent_phrase(self, kick, keeper_address):
         # given
-        flipper = c.flipper
-        (model, model_factory) = models(keeper, kick)
+        flipper = self.collateral.flipper
+        (model, model_factory) = models(self.keeper, kick)
 
         # when
         our_bid_price = Wad.from_number(150)
         assert our_bid_price * flipper.bids(kick).lot > Wad(flipper.bids(1).tab)
 
-        self.simulate_model_bid(mcd, c, model, our_bid_price)
+        self.simulate_model_bid(self.mcd, self.collateral, model, our_bid_price)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -448,9 +426,9 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         assert auction.lot == tend_lot
 
         # when
-        reserve_dai(mcd, c, keeper_address, Wad(auction.tab))
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        reserve_dai(self.mcd, self.collateral, keeper_address, Wad(auction.tab))
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -462,18 +440,17 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_use_most_up_to_date_price_for_dent_even_if_it_gets_updated_during_tend(self, mcd, c, kick, keeper,
-                                                                                           keeper_address):
+    def test_should_use_most_up_to_date_price_for_dent_even_if_it_gets_updated_during_tend(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
         first_bid_price = Wad.from_number(140)
-        self.simulate_model_bid(mcd, c, model, first_bid_price)
+        self.simulate_model_bid(self.mcd, self.collateral, model, first_bid_price)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -482,10 +459,10 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
 
         # when
         second_bid_price = Wad.from_number(150)
-        self.simulate_model_bid(mcd, c, model, second_bid_price)
+        self.simulate_model_bid(self.mcd, self.collateral, model, second_bid_price)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         auction = flipper.bids(kick)
         assert auction.bid == auction.tab
@@ -495,18 +472,18 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_only_tend_if_bid_is_only_slightly_above_tab(self, mcd, c, kick, keeper, keeper_address):
+    def test_should_only_tend_if_bid_is_only_slightly_above_tab(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
         auction = flipper.bids(kick)
         bid_price = Wad(auction.tab) + Wad.from_number(0.1)
-        self.simulate_model_bid(mcd, c, model, bid_price)
+        self.simulate_model_bid(self.mcd, self.collateral, model, bid_price)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -514,7 +491,7 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         assert auction.lot == tend_lot
 
         # when
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -525,22 +502,21 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_tend_up_to_exactly_tab_if_bid_is_only_slightly_below_tab(self, mcd, c, kick, keeper,
-                                                                             keeper_address):
+    def test_should_tend_up_to_exactly_tab_if_bid_is_only_slightly_below_tab(self, kick):
         """I assume the point of this test is that the bid increment should be ignored when `tend`ing the `tab`
         to transition the auction into _dent_ phase."""
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
         auction = flipper.bids(kick)
         assert auction.bid == Rad(0)
         bid_price = Wad(auction.tab / Rad(tend_lot)) - Wad.from_number(0.01)
-        self.simulate_model_bid(mcd, c, model, bid_price)
+        self.simulate_model_bid(self.mcd, self.collateral, model, bid_price)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -550,10 +526,10 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
 
         # when
         price_to_reach_tab = Wad(auction.tab / Rad(tend_lot)) + Wad(1)
-        self.simulate_model_bid(mcd, c, model, price_to_reach_tab)
+        self.simulate_model_bid(self.mcd, self.collateral, model, price_to_reach_tab)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         auction = flipper.bids(kick)
@@ -564,26 +540,26 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_overbid_itself_if_model_has_updated_the_price(self, mcd, c, kick, keeper, keeper_address):
+    def test_should_overbid_itself_if_model_has_updated_the_price(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
         first_bid = Wad.from_number(15.0)
-        self.simulate_model_bid(mcd, c, model, first_bid)
+        self.simulate_model_bid(self.mcd, self.collateral, model, first_bid)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick).bid == Rad(first_bid * tend_lot)
 
         # when
         second_bid = Wad.from_number(20.0)
-        self.simulate_model_bid(mcd, c, model, second_bid)
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.simulate_model_bid(self.mcd, self.collateral, model, second_bid)
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick).bid == Rad(second_bid * tend_lot)
@@ -592,28 +568,26 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    @pytest.mark.skip("Mocking a pending transaction isn't working")
-    def test_should_increase_gas_price_of_pending_transactions_if_model_increases_gas_price(self, mcd, c, kick, keeper):
+    def test_should_increase_gas_price_of_pending_transactions_if_model_increases_gas_price(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
         bid_price = Wad.from_number(20.0)
-        reserve_dai(mcd, c, self.keeper_address, bid_price * tend_lot * 2)
+        reserve_dai(self.mcd, self.collateral, self.keeper_address, bid_price * tend_lot * 2)
         simulate_model_output(model=model, price=bid_price, gas_price=10)
         # and
         self.start_ignoring_transactions()
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
-        wait_for_other_threads()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         # and
         self.end_ignoring_transactions()
         # and
         simulate_model_output(model=model, price=bid_price, gas_price=15)
         # and
-        keeper.check_for_bids()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick).bid == Rad(bid_price * tend_lot)
@@ -623,25 +597,25 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_replace_pending_transactions_if_model_raises_bid_and_increases_gas_price(self, mcd, c, kick,
-                                                                                             keeper):
+    def test_should_replace_pending_transactions_if_model_raises_bid_and_increases_gas_price(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
 
         # when
-        self.simulate_model_bid(mcd, c, model, price=Wad.from_number(15.0), gas_price=10)
+        reserve_dai(self.mcd, self.collateral, self.keeper_address, Wad.from_number(35.0) * tend_lot * 2)
+        simulate_model_output(model=model, price=Wad.from_number(15.0), gas_price=10)
         # and
         self.start_ignoring_transactions()
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         # and
         self.end_ignoring_transactions()
         # and
-        self.simulate_model_bid(mcd, c, model, price=Wad.from_number(20.0), gas_price=15)
+        simulate_model_output(model=model, price=Wad.from_number(20.0), gas_price=15)
         # and
-        keeper.check_for_bids()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick).bid == Rad(Wad.from_number(20.0) * tend_lot)
@@ -651,29 +625,30 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_replace_pending_transactions_if_model_lowers_bid_and_increases_gas_price(self, mcd, c, kick,
-                                                                                             keeper):
+    def test_should_replace_pending_transactions_if_model_lowers_bid_and_increases_gas_price(self, kick):
         """ Assuming we want all bids to be submitted as soon as output from the model is parsed,
         this test seems impractical.  In real applications, the model would be unable to submit a lower bid. """
         # given
-        (model, model_factory) = models(keeper, kick)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick)
+        flipper = self.collateral.flipper
+        assert self.mcd.web3 == self.web3
 
         # when
         bid_price = Wad.from_number(20.0)
-        reserve_dai(mcd, c, self.keeper_address, bid_price * tend_lot)
+        reserve_dai(self.mcd, self.collateral, self.keeper_address, bid_price * tend_lot)
         simulate_model_output(model=model, price=Wad.from_number(20.0), gas_price=10)
         # and
         self.start_ignoring_transactions()
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         # and
         self.end_ignoring_transactions()
         # and
         simulate_model_output(model=model, price=Wad.from_number(15.0), gas_price=15)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick).bid == Rad(Wad.from_number(15.0) * tend_lot)
@@ -683,17 +658,17 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         assert flipper.deal(kick).transact()
 
-    def test_should_not_tend_on_rounding_errors_with_small_amounts(self, mcd, c, kick_small_lot, keeper):
+    def test_should_not_tend_on_rounding_errors_with_small_amounts(self, kick_small_lot):
         # given
-        (model, model_factory) = models(keeper, kick_small_lot)
-        flipper = c.flipper
+        (model, model_factory) = models(self.keeper, kick_small_lot)
+        flipper = self.collateral.flipper
 
         # when
         bid_price = Wad.from_number(3.0)
-        self.simulate_model_bid(mcd, c, model, bid_price)
+        self.simulate_model_bid(self.mcd, self.collateral, model, bid_price)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick_small_lot).bid == Rad(bid_price * tend_small_lot)
@@ -701,25 +676,25 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         # when
         tx_count = self.web3.eth.getTransactionCount(self.keeper_address.address)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert self.web3.eth.getTransactionCount(self.keeper_address.address) == tx_count
 
-    def test_should_not_dent_on_rounding_errors_with_small_amounts(self, mcd, c, keeper):
+    def test_should_not_dent_on_rounding_errors_with_small_amounts(self):
         # given
-        flipper = c.flipper
+        flipper = self.collateral.flipper
         kick_small_lot = flipper.kicks()
-        (model, model_factory) = models(keeper, kick_small_lot)
+        (model, model_factory) = models(self.keeper, kick_small_lot)
 
         # when
         auction = flipper.bids(kick_small_lot)
         bid_price = Wad(auction.tab / Rad(tend_small_lot))
-        self.simulate_model_bid(mcd, c, model, bid_price)
+        self.simulate_model_bid(self.mcd, self.collateral, model, bid_price)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick_small_lot).lot == auction.lot
@@ -727,44 +702,44 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         # when
         tx_count = self.web3.eth.getTransactionCount(self.keeper_address.address)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert self.web3.eth.getTransactionCount(self.keeper_address.address) == tx_count
 
-    def test_should_deal_when_we_won_the_auction(self, mcd, c, keeper):
+    def test_should_deal_when_we_won_the_auction(self):
         # given
-        flipper = c.flipper
+        flipper = self.collateral.flipper
         kick = flipper.kicks()
 
         # when
-        collateral_before = c.gem.balance_of(self.keeper_address)
+        collateral_before = self.collateral.gem.balance_of(self.keeper_address)
 
         # when
         time_travel_by(self.web3, flipper.ttl() + 1)
         lot_won = flipper.bids(kick).lot
         assert lot_won > Wad(0)
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
-        assert c.adapter.exit(self.keeper_address, lot_won).transact(from_address=self.keeper_address)
+        assert self.collateral.adapter.exit(self.keeper_address, lot_won).transact(from_address=self.keeper_address)
         # then
-        collateral_after = c.gem.balance_of(self.keeper_address)
+        collateral_after = self.collateral.gem.balance_of(self.keeper_address)
         assert collateral_before < collateral_after
 
-    def test_should_not_deal_when_auction_finished_but_somebody_else_won(self, mcd, c, kick, keeper, other_address):
+    def test_should_not_deal_when_auction_finished_but_somebody_else_won(self, kick, other_address):
         # given
-        flipper = c.flipper
+        flipper = self.collateral.flipper
         # and
         bid = Rad.from_number(66)
-        self.tend_with_dai(mcd, c, flipper, kick, other_address, bid)
+        self.tend_with_dai(self.mcd, self.collateral, flipper, kick, other_address, bid)
         assert flipper.bids(kick).bid == bid
 
         # when
         time_travel_by(self.web3, flipper.ttl() + 1)
         # and
-        keeper.check_all_auctions()
+        self.keeper.check_all_auctions()
         wait_for_other_threads()
         # then ensure the bid hasn't been deleted
         assert flipper.bids(kick).bid == bid
@@ -773,30 +748,30 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         assert flipper.deal(kick).transact()
         assert flipper.bids(kick).bid == Rad(0)
 
-    def test_should_obey_gas_price_provided_by_the_model(self, mcd, c, kick, keeper):
+    def test_should_obey_gas_price_provided_by_the_model(self, kick):
         # given
-        (model, model_factory) = models(keeper, kick)
+        (model, model_factory) = models(self.keeper, kick)
 
         # when
-        self.simulate_model_bid(mcd, c, model, price=Wad.from_number(15.0), gas_price=175000)
+        self.simulate_model_bid(self.mcd, self.collateral, model, price=Wad.from_number(15.0), gas_price=175000)
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
-        assert c.flipper.bids(kick).bid == Rad(Wad.from_number(15.0) * tend_lot)
+        assert self.collateral.flipper.bids(kick).bid == Rad(Wad.from_number(15.0) * tend_lot)
         assert self.web3.eth.getBlock('latest', full_transactions=True).transactions[0].gasPrice == 175000
 
-    def test_should_use_default_gas_price_if_not_provided_by_the_model(self, mcd, c, kick, keeper):
+    def test_should_use_default_gas_price_if_not_provided_by_the_model(self, kick):
         # given
-        flipper = c.flipper
-        (model, model_factory) = models(keeper, kick)
+        flipper = self.collateral.flipper
+        (model, model_factory) = models(self.keeper, kick)
 
         # when
-        self.simulate_model_bid(mcd, c, model, price=Wad.from_number(16.0))
+        self.simulate_model_bid(self.mcd, self.collateral, model, price=Wad.from_number(16.0))
         # and
-        keeper.check_all_auctions()
-        keeper.check_for_bids()
+        self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
         assert flipper.bids(kick).bid == Rad(Wad.from_number(16.0) * tend_lot)

--- a/tests/test_flop.py
+++ b/tests/test_flop.py
@@ -437,8 +437,6 @@ class TestAuctionKeeperFlopper(TransactionIgnoringTest):
         self.keeper.check_all_auctions()
         self.keeper.check_for_bids()
         # and
-        time.sleep(2)
-        # and
         self.end_ignoring_transactions()
         # and
         simulate_model_output(model=model, price=Wad.from_number(120.0), gas_price=15)


### PR DESCRIPTION
Fix and write tests around `start/end_ignoring_transactions` mechanism, used to mock replacement of a transaction.  Refactored all the `flip` tests to reuse the keeper instance, preventing some `asyncio` event loop weirdness.