### PR TITLE
Remove rpc-port parameter

### DIFF
--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -50,8 +50,6 @@ class AuctionKeeper:
 
         parser.add_argument("--rpc-host", type=str, default="http://localhost:8545",
                             help="JSON-RPC endpoint URI with port (default: `http://localhost:8545')")
-        parser.add_argument("--rpc-port", type=int, default=8545,
-                            help="JSON-RPC port (deprecated) to support legacy configs")
         parser.add_argument("--rpc-timeout", type=int, default=10,
                             help="JSON-RPC timeout (in seconds, default: 10)")
 
@@ -119,12 +117,8 @@ class AuctionKeeper:
         self.arguments = parser.parse_args(args)
 
         # Configure connection to the chain
-        if self.arguments.rpc_host.startswith("http"):  # http connection
-            provider = HTTPProvider(endpoint_uri=self.arguments.rpc_host,
-                                    request_kwargs={'timeout': self.arguments.rpc_timeout})
-        else:  # legacy config; separate host and port
-            provider = HTTPProvider(endpoint_uri=f"http://{self.arguments.rpc_host}:{self.arguments.rpc_port}",
-                                    request_kwargs={'timeout': self.arguments.rpc_timeout})
+        provider = HTTPProvider(endpoint_uri=self.arguments.rpc_host,
+                                request_kwargs={'timeout': self.arguments.rpc_timeout})
         self.web3: Web3 = kwargs['web3'] if 'web3' in kwargs else Web3(provider)
         self.web3.eth.defaultAccount = self.arguments.eth_from
         register_keys(self.web3, self.arguments.eth_key)


### PR DESCRIPTION
The existence of `rpc-port` made it difficult for individuals to configure endpoints.  It wasn't obvious that the port would not be appended if their URI started with `http`, and that behavior was unnatural to begin with.  Removal of the parameter greatly simplifies configuration while allowing endpoints regardless of where the port belongs in the URI (for example `https://mynodehost:443/api-key=foo`.

It is understand that many consumers will need to adjust their shell scripts.  The dockerized keeper will also need to be updated accordingly.