### PR TITLE
Improve handling of block reorgs

### DIFF
--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -43,6 +43,7 @@ from auction_keeper.urn_history import UrnHistory
 
 class AuctionKeeper:
     logger = logging.getLogger()
+    dead_after = 10  # Assume block reorgs cannot resurrect an auction id after this many blocks
 
     def __init__(self, args: list, **kwargs):
         parser = argparse.ArgumentParser(prog='auction-keeper')
@@ -182,7 +183,7 @@ class AuctionKeeper:
                                  flopper=self.flopper.address if self.flopper else None,
                                  model_factory=ModelFactory(' '.join(self.arguments.model)))
         self.auctions_lock = threading.Lock()
-        self.dead_auctions = set()
+        self.dead_since = {}
         self.lifecycle = None
 
         logging.basicConfig(format='%(asctime)-15s %(levelname)-8s %(message)s',
@@ -505,9 +506,11 @@ class AuctionKeeper:
     #     for example).
     def check_auction(self, id: int) -> bool:
         assert isinstance(id, int)
+        current_block = self.web3.eth.blockNumber
+        assert isinstance(current_block, int)
 
         # Improves performance by avoiding an onchain call to check auctions we know have completed.
-        if id in self.dead_auctions:
+        if id in self.dead_since and current_block - self.dead_since[id] > 10:
             return False
 
         # Read auction information from the chain
@@ -520,7 +523,7 @@ class AuctionKeeper:
             # Try to remove the auction so the model terminates and we stop tracking it.
             # If auction has already been removed, nothing happens.
             self.auctions.remove_auction(id)
-            self.dead_auctions.add(id)
+            self.dead_since[id] = current_block
             return False
 
         # Check if the auction is finished.  If so configured, `deal` the auction.
@@ -538,7 +541,7 @@ class AuctionKeeper:
             # Remove the auction so the model terminates and we stop tracking it.
             # If auction has already been removed, nothing happens.
             self.auctions.remove_auction(id)
-            self.dead_auctions.add(id)
+            self.dead_since[id] = current_block
             return False
 
         else:

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -650,7 +650,6 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         # and
         simulate_model_output(model=model, price=Wad.from_number(15.0), gas_price=15)
         # and
-        self.keeper.check_all_auctions()
         self.keeper.check_for_bids()
         wait_for_other_threads()
         # then


### PR DESCRIPTION
By checking auction status until each auction has been finished for 10 blocks, we handle corner cases where a block reorg changes the state of the auction.  Reorgs are rarely more than a block deep, and `10` was discussed as a "safe" number.  This was intentionally made non-configurable due to the existing complexity of managing keeper configuration.