### PR TITLE
Stop Re-approving dai if already approved

### DIFF
--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -298,7 +298,10 @@ class AuctionKeeper:
         self.strategy.approve(gas_price=self.gas_price)
         time.sleep(2)
         if self.dai_join:
-            self.mcd.approve_dai(usr=self.our_address, gas_price=self.gas_price)
+            if self.mcd.dai.allowance_of(self.our_address, self.dai_join.address) > Wad.from_number(2**50):
+                return
+            else:
+                self.mcd.approve_dai(usr=self.our_address, gas_price=self.gas_price)
 
     def shutdown(self):
         with self.auctions_lock:


### PR DESCRIPTION
Currently the keeper sends a new approve transaction each time it is restarted for flip auction to approve the dai_join contract for dai deposits.  This change checks the default account allowance and only send the approve transaction if it is not already approved. 