### PR TITLE
Query urn state for all cached urns

### DIFF
--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -170,8 +170,9 @@ class AuctionKeeper:
         if self.flipper:
             self.min_flip_lot = Wad.from_number(self.arguments.min_flip_lot)
             self.strategy = FlipperStrategy(self.flipper, self.min_flip_lot)
-            self.urn_history = UrnHistory(self.web3, self.mcd, self.ilk, self.arguments.from_block,
-                                          self.arguments.vulcanize_endpoint, self.arguments.vulcanize_key)
+            if self.arguments.create_auctions:
+                self.urn_history = UrnHistory(self.web3, self.mcd, self.ilk, self.arguments.from_block,
+                                              self.arguments.vulcanize_endpoint, self.arguments.vulcanize_key)
         elif self.flapper:
             self.strategy = FlapperStrategy(self.flapper, self.mkr.address)
         elif self.flopper:

--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -217,7 +217,6 @@ class AuctionKeeper:
         logging.getLogger("asyncio").setLevel(logging.INFO)
         logging.getLogger("requests").setLevel(logging.INFO)
 
-
     def main(self):
         def seq_func(check_func: callable):
             assert callable(check_func)
@@ -351,7 +350,7 @@ class AuctionKeeper:
 
         # Look for unsafe CDPs and bite them
         urns = self.urn_history.get_urns()
-        logging.debug(f"Initial query of {len(urns)} {self.ilk} urns to be evaluated and bitten if any are unsafe")
+        logging.debug(f"Evaluating {len(urns)} {self.ilk} urns to be bitten if any are unsafe")
 
         for urn in urns.values():
             safe = urn.ink * ilk.spot >= urn.art * rate

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -263,3 +263,17 @@ class TestConfig:
                                            f"--deal-for ALL "
                                            f"--model ./bogus-model.sh"), web3=web3)
         assert deal_all.deal_all
+
+    def test_shouldnt_need_urn_history_when_only_bidding(self, web3, keeper_address: Address):
+        with pytest.raises(RuntimeError) as e:
+            AuctionKeeper(args=args(f"--eth-from {keeper_address} "
+                                    f"--type flip "
+                                    f"--ilk ETH-A "
+                                    f"--model ./bogus-model.sh"), web3=web3)
+
+        keeper = AuctionKeeper(args=args(f"--eth-from {keeper_address} "
+                                         f"--type flip "
+                                         f"--ilk ETH-A "
+                                         f"--bid-only "
+                                         f"--model ./bogus-model.sh"), web3=web3)
+        assert keeper.urn_history is None


### PR DESCRIPTION
To rationalize this change, let's discuss the implementation before https://github.com/makerdao/auction-keeper/pull/68.  Unless noted otherwise, examples are based on ETH-A and a mainnet Parity node.
- Without Vulcanize, ETH-A and BAT-A vaults couldn't be bitten by this keeper.  The keeper would attempt to continuously pull entire chain history from the `--from-block`.  The old implementation of `past_frobs`, without its batching mechanism, has been unable to do this for several months.
- With a Vulcanize instance, urn state could be checked in under a minute.  These queries were deprecated by VDB, and updated queries exceeded VDB query cost restrictions.

PR#68 attempted to resolve those issues by creating a cache of urn state.  However, that PR introduced a bug where urn state was not updated when `cat.bite` and `vat.fork` operations were performed after initialization of the cache.  Rolling back that PR didn't make sense: Users without a Vulcanize instance would once again be unable to `bite`.

This PR resolves the problem by continuously refreshing the state of all urns.  As such:
- Without Vulcanize, initializing urn history will cost about 37 minutes, and updating urn state will cost about 6 minutes each iteration.
- With Vulcanize, urn history can be initialized in 6 minutes, and updating urn state will also cost about 6 minutes each iteration.
Other collateral types cost under 1 minute each iteration.  Future enhancement is possible by either reading more event logs from the chain (likely requiring `pymaker` changes) or utilizing Vulcanize in a different manor.

Other changes:
- Don't require users to specify arguments which aren't used for keepers not configured to `bite`.
- Update README to more accurately discuss performance limitations when biting.