### PR TITLE
Vat Reservoir - accounting improvement

### DIFF
--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -504,6 +504,8 @@ class AuctionKeeper:
 
     def check_for_bids(self):
         # Initialize the reservoir with Dai/MKR balance for this round of bid submissions.
+        # This isn't a perfect solution as it omits the cost of bids submitted from the last round.
+        # Recreating the reservoir preserves the stateless design of this keeper.
         if self.flipper or self.flopper:
             reservoir = Reservoir(self.vat.dai(self.our_address))
         elif self.flapper:
@@ -663,7 +665,7 @@ class AuctionKeeper:
                 if not already_rebalanced:
                     # Try to synchronously join Dai the Vat
                     if self.is_joining_dai:
-                        self.logger.debug(f"Bid cost {str(cost)} exceeds reservoir level of {reservoir.level}; "
+                        self.logger.info(f"Bid cost {str(cost)} exceeds reservoir level of {reservoir.level}; "
                                           "waiting for Dai to rebalance")
                         return False
                     else:
@@ -672,7 +674,7 @@ class AuctionKeeper:
                             reservoir.refill(Rad(rebalanced))
                             return self.check_bid_cost(id, cost, reservoir, already_rebalanced=True)
 
-                self.logger.debug(f"Bid cost {str(cost)} exceeds reservoir level of {reservoir.level}; "
+                self.logger.info(f"Bid cost {str(cost)} exceeds reservoir level of {reservoir.level}; "
                                   "bid will not be submitted")
                 return False
         # If this is an auction where we bid with MKR...

--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -36,7 +36,7 @@ from pymaker.model import Token
 from pymaker.numeric import Wad, Ray, Rad
 
 from auction_keeper.gas import DynamicGasPrice, UpdatableGasPrice
-from auction_keeper.logic import Auction, Auctions
+from auction_keeper.logic import Auction, Auctions, Reservoir
 from auction_keeper.model import ModelFactory
 from auction_keeper.strategy import FlopperStrategy, FlapperStrategy, FlipperStrategy
 from auction_keeper.urn_history import UrnHistory
@@ -503,6 +503,14 @@ class AuctionKeeper:
                          f"{(datetime.now() - started).seconds} seconds")
 
     def check_for_bids(self):
+        # Initialize the reservoir with Dai/MKR balance for this round of bid submissions.
+        if self.flipper or self.flopper:
+            reservoir = Reservoir(self.vat.dai(self.our_address))
+        elif self.flapper:
+            reservoir = Reservoir(Rad(self.mkr.balance_of(self.our_address)))
+        else:
+            raise RuntimeError("Unsupported auction type")
+        
         with self.auctions_lock:
             for id, auction in self.auctions.auctions.items():
                 # If we're exiting, release the lock around checking price models
@@ -511,7 +519,7 @@ class AuctionKeeper:
 
                 if not self.auction_handled_by_this_shard(id):
                     continue
-                self.handle_bid(id=id, auction=auction)
+                self.handle_bid(id=id, auction=auction, reservoir=reservoir)
 
     # TODO if we will introduce multithreading here, proper locking should be introduced as well
     #     locking should not happen on `auction.lock`, but on auction.id here. as sometimes we will
@@ -573,9 +581,10 @@ class AuctionKeeper:
         # Feed the model with current state
         auction.feed_model(input)
 
-    def handle_bid(self, id: int, auction: Auction):
+    def handle_bid(self, id: int, auction: Auction, reservoir: Reservoir):
         assert isinstance(id, int)
         assert isinstance(auction, Auction)
+        assert isinstance(reservoir, Reservoir)
 
         output = auction.model_output()
         if output is None:
@@ -585,7 +594,7 @@ class AuctionKeeper:
         # If we can't afford the bid, log a warning/error and back out.
         # By continuing, we'll burn through gas fees while the keeper pointlessly retries the bid.
         if cost is not None:
-            if not self.check_bid_cost(cost):
+            if not self.check_bid_cost(id, cost, reservoir):
                 return
 
         if bid_price is not None and bid_transact is not None:
@@ -644,32 +653,33 @@ class AuctionKeeper:
                 self._run_future(bid_transact.transact_async(replace=transaction_in_progress,
                                                              gas_price=auction.gas_price))
 
-    def check_bid_cost(self, cost: Rad, already_rebalanced=False) -> bool:
+    def check_bid_cost(self, id: int, cost: Rad, reservoir: Reservoir, already_rebalanced=False) -> bool:
+        assert isinstance(id, int)
         assert isinstance(cost, Rad)
 
         # If this is an auction where we bid with Dai...
         if self.flipper or self.flopper:
-            vat_dai = self.vat.dai(self.our_address)
-            if cost > vat_dai:
+            if not reservoir.check_bid_cost(id, cost):
                 if not already_rebalanced:
                     # Try to synchronously join Dai the Vat
                     if self.is_joining_dai:
-                        self.logger.debug(f"Bid cost {str(cost)} exceeds vat balance of {vat_dai}; "
+                        self.logger.debug(f"Bid cost {str(cost)} exceeds reservoir level of {reservoir.level}; "
                                           "waiting for Dai to rebalance")
                         return False
                     else:
                         rebalanced = self.rebalance_dai()
                         if rebalanced and rebalanced > Wad(0):
-                            return self.check_bid_cost(cost, already_rebalanced=True)
+                            reservoir.refill(Rad(rebalanced))
+                            return self.check_bid_cost(id, cost, reservoir, already_rebalanced=True)
 
-                self.logger.debug(f"Bid cost {str(cost)} exceeds vat balance of {vat_dai}; "
+                self.logger.debug(f"Bid cost {str(cost)} exceeds reservoir level of {reservoir.level}; "
                                   "bid will not be submitted")
                 return False
         # If this is an auction where we bid with MKR...
         elif self.flapper:
             mkr_balance = self.mkr.balance_of(self.our_address)
             if cost > Rad(mkr_balance):
-                self.logger.debug(f"Bid cost {str(cost)} exceeds MKR balance of {mkr_balance}; "
+                self.logger.debug(f"Bid cost {str(cost)} exceeds reservoir level of {reservoir.level}; "
                                   "bid will not be submitted")
                 return False
         return True

--- a/tests/manual_test_create_unsafe_vault.py
+++ b/tests/manual_test_create_unsafe_vault.py
@@ -100,7 +100,6 @@ def handle_returned_collateral():
 create_risky_vault()
 
 
-
 while True:
     time.sleep(6)
     urn = mcd.vat.urn(collateral.ilk, our_address)

--- a/tests/manual_test_create_unsafe_vault.py
+++ b/tests/manual_test_create_unsafe_vault.py
@@ -96,8 +96,7 @@ def handle_returned_collateral():
         logging.info(f"Attempting to exit {dai_balance} Dai")
         mcd.dai_adapter.exit(our_address, dai_balance).transact()
 
-
-create_risky_vault()
+# create_risky_vault()
 
 
 while True:

--- a/tests/manual_test_create_unsafe_vault.py
+++ b/tests/manual_test_create_unsafe_vault.py
@@ -96,7 +96,9 @@ def handle_returned_collateral():
         logging.info(f"Attempting to exit {dai_balance} Dai")
         mcd.dai_adapter.exit(our_address, dai_balance).transact()
 
-# create_risky_vault()
+
+create_risky_vault()
+
 
 
 while True:

--- a/tests/manual_test_create_unsafe_vault.py
+++ b/tests/manual_test_create_unsafe_vault.py
@@ -52,6 +52,7 @@ urn = mcd.vat.urn(collateral.ilk, our_address)
 # mcd.approve_dai(our_address)
 # Transact.gas_estimate_for_bad_txs = 20000
 osm_price = collateral.pip.peek()
+action = sys.argv[4] if len(sys.argv) > 4 else "create"
 
 
 def r(value, decimals=1):

--- a/tests/random_bid.py
+++ b/tests/random_bid.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+import sys
+import json
+import random
+
+max_price = float(sys.argv[1]) if len(sys.argv) > 1 else 1000
+
+for line in sys.stdin:
+    signal = json.loads(line)
+    auction_id = signal['id']
+    assert isinstance(auction_id, int)
+
+    random.seed(a=auction_id)
+    price = max_price * random.random()
+
+    stance = {'price': price}
+    print(json.dumps(stance), flush=True)

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -150,12 +150,12 @@ class TestVatDaiTarget(TestVatDai):
 
 
 class TestEmptyVatOnExit(TestVatDai):
-    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_behavior):
+    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_on_shutdown: bool):
         assert isinstance(exit_dai_on_shutdown, bool)
-        assert isinstance(exit_gem_behavior, str) or exit_gem_behavior is None
+        assert isinstance(exit_gem_on_shutdown, bool)
 
         vat_dai_behavior = "" if exit_dai_on_shutdown else "--keep-dai-in-vat-on-exit"
-        vat_gem_behavior = "" if exit_gem_behavior else f"--return-gem-behavior {exit_gem_behavior}"
+        vat_gem_behavior = "" if exit_gem_on_shutdown else "--keep-gem-in-vat-on-exit"
 
         keeper = AuctionKeeper(args=args(f"--eth-from {self.keeper_address} "
                                          f"--type flip --ilk {self.collateral.ilk.name} "
@@ -173,7 +173,7 @@ class TestEmptyVatOnExit(TestVatDai):
 
     def test_do_not_empty(self):
         # given dai and gem in the vat
-        keeper = self.create_keeper(False, "NONE")
+        keeper = self.create_keeper(False, False)
         purchase_dai(Wad.from_number(153), self.keeper_address)
         assert self.get_dai_token_balance() >= Wad.from_number(153)
         assert self.mcd.dai_adapter.join(self.keeper_address, Wad.from_number(153)).transact(
@@ -202,7 +202,7 @@ class TestEmptyVatOnExit(TestVatDai):
         gem_vat_balance_before = self.get_gem_vat_balance()
 
         # when creating and shutting down the keeper
-        keeper = self.create_keeper(True, "none")
+        keeper = self.create_keeper(True, False)
         keeper.shutdown()
 
         # then ensure the dai was emptied
@@ -224,7 +224,7 @@ class TestEmptyVatOnExit(TestVatDai):
         dai_token_balance_before = self.get_dai_token_balance()
         dai_vat_balance_before = self.get_dai_vat_balance()
         # and creating and shutting down the keeper
-        keeper = self.create_keeper(False, "onexit")
+        keeper = self.create_keeper(False, True)
         keeper.shutdown()
 
         # then ensure dai was not emptied

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -150,12 +150,12 @@ class TestVatDaiTarget(TestVatDai):
 
 
 class TestEmptyVatOnExit(TestVatDai):
-    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_on_shutdown: bool):
+    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_behavior):
         assert isinstance(exit_dai_on_shutdown, bool)
-        assert isinstance(exit_gem_on_shutdown, bool)
+        assert isinstance(exit_gem_behavior, str) or exit_gem_behavior is None
 
         vat_dai_behavior = "" if exit_dai_on_shutdown else "--keep-dai-in-vat-on-exit"
-        vat_gem_behavior = "" if exit_gem_on_shutdown else "--keep-gem-in-vat-on-exit"
+        vat_gem_behavior = "" if exit_gem_behavior else f"--return-gem-behavior {exit_gem_behavior}"
 
         keeper = AuctionKeeper(args=args(f"--eth-from {self.keeper_address} "
                                          f"--type flip --ilk {self.collateral.ilk.name} "
@@ -173,7 +173,7 @@ class TestEmptyVatOnExit(TestVatDai):
 
     def test_do_not_empty(self):
         # given dai and gem in the vat
-        keeper = self.create_keeper(False, False)
+        keeper = self.create_keeper(False, "NONE")
         purchase_dai(Wad.from_number(153), self.keeper_address)
         assert self.get_dai_token_balance() >= Wad.from_number(153)
         assert self.mcd.dai_adapter.join(self.keeper_address, Wad.from_number(153)).transact(
@@ -202,7 +202,7 @@ class TestEmptyVatOnExit(TestVatDai):
         gem_vat_balance_before = self.get_gem_vat_balance()
 
         # when creating and shutting down the keeper
-        keeper = self.create_keeper(True, False)
+        keeper = self.create_keeper(True, "none")
         keeper.shutdown()
 
         # then ensure the dai was emptied
@@ -224,7 +224,7 @@ class TestEmptyVatOnExit(TestVatDai):
         dai_token_balance_before = self.get_dai_token_balance()
         dai_vat_balance_before = self.get_dai_vat_balance()
         # and creating and shutting down the keeper
-        keeper = self.create_keeper(False, True)
+        keeper = self.create_keeper(False, "onexit")
         keeper.shutdown()
 
         # then ensure dai was not emptied


### PR DESCRIPTION
Assume the keeper needs to submit multiple bids, whose total exceeds the amount of liquidity available.  Although we check `vat` balance before submitting each bid, the balance doesn't decrease after each transaction is asynchronously submitted.  The balance only changes when those transactions are mined several seconds later.  As such, only the first bid will have an accurate balance.

With this change, we fill a reservoir with the vat balance at the beginning of the bid check across all auctions.  Each time the strategy sees a viable bidding opportunity, we subtract the cost of the bid upon submission.  This prevents the keeper from burning gas on transactions which will fail due to the vat balance being too low by the time they are mined.

To maintain statelessness, the reservoir is recreated each time the keeper runs the routine to find bid opportunities.  Due to the nondeterminism of when transactions are mined, cases remain where bids could be submitted with insufficient balance.  This change reduces the probability of those failures, saving gas.
