### PR TITLE
Add Tick support for all auction types

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,6 @@ the following actions:
 * The keeper does not check model prices until an auction exists.  When configured to create new auctions, it will 
 `bite`, `flap`, or `flop` in response to opportunities regardless of whether or not your Dai or MKR balance is 
 sufficient to participate.  This too imposes a gas fee.
-* When using `--vat-dai-target` to manage Vat inventory: After procuring more Dai, the keeper should be restarted to add
-Dai to the Vat.
 * Biting vaults to kick off new collateral auctions is an expensive operation.  To do so without a VulcanizeDB 
 subscription, the keeper initializes a cache of urn state by scraping event logs from the chain.  The keeper will then 
 continuously refresh urn state to detect undercollateralized urns.

--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -547,7 +547,7 @@ class AuctionKeeper:
                     self.strategy.tick(id).transact(gas_price=self.gas_price)
                     return True
             elif self.deal_all or input.guy in self.deal_for:
-                self.strategy.deal(id).transact_async(gas_price=self.gas_price)
+                self.strategy.deal(id).transact(gas_price=self.gas_price)
 
                 # Upon winning a flip or flop auction, we may need to replenish Dai to the Vat.
                 # Upon winning a flap auction, we may want to withdraw won Dai from the Vat.

--- a/auction_keeper/strategy.py
+++ b/auction_keeper/strategy.py
@@ -22,7 +22,7 @@ from web3 import Web3
 from auction_keeper.model import Status
 from pymaker import Address, Transact
 from pymaker.approval import directly, hope_directly
-from pymaker.auctions import Flopper, Flapper, Flipper
+from pymaker.auctions import AuctionContract, Flopper, Flapper, Flipper
 from pymaker.gas import GasPrice
 from pymaker.numeric import Wad, Ray, Rad
 
@@ -34,17 +34,28 @@ def era(web3: Web3):
 class Strategy:
     logger = logging.getLogger()
 
-    def approve(self):
+    def __init__(self, contract: AuctionContract):
+        assert isinstance(contract, AuctionContract)
+        self.contract = contract
+
+    def approve(self, gas_price: GasPrice):
         raise NotImplementedError
 
     def get_input(self, id: int):
         raise NotImplementedError
+
+    def deal(self, id: int) -> Transact:
+        return self.contract.deal(id)
+
+    def tick(self, id: int) -> Transact:
+        return self.contract.tick(id)
 
 
 class FlipperStrategy(Strategy):
     def __init__(self, flipper: Flipper, min_lot: Wad):
         assert isinstance(flipper, Flipper)
         assert isinstance(min_lot, Wad)
+        super().__init__(flipper)
 
         self.flipper = flipper
         self.beg = flipper.beg()
@@ -112,14 +123,12 @@ class FlipperStrategy(Strategy):
                 self.logger.debug(f"tend bid {our_bid} would not exceed the bid increment for auction {id}")
                 return None, None, None
 
-    def deal(self, id: int) -> Transact:
-        return self.flipper.deal(id)
-
 
 class FlapperStrategy(Strategy):
     def __init__(self, flapper: Flapper, mkr: Address):
         assert isinstance(flapper, Flapper)
         assert isinstance(mkr, Address)
+        super().__init__(flapper)
 
         self.flapper = flapper
         self.beg = flapper.beg()
@@ -165,13 +174,11 @@ class FlapperStrategy(Strategy):
             self.logger.debug(f"bid {our_bid} would not exceed the bid increment for auction {id}")
             return None, None, None
 
-    def deal(self, id: int) -> Transact:
-        return self.flapper.deal(id)
-
 
 class FlopperStrategy(Strategy):
     def __init__(self, flopper: Flopper):
         assert isinstance(flopper, Flopper)
+        super().__init__(flopper)
 
         self.flopper = flopper
         self.beg = flopper.beg()
@@ -215,6 +222,3 @@ class FlopperStrategy(Strategy):
         else:
             self.logger.debug(f"lot {our_lot} would not exceed the bid increment for auction {id}")
             return None, None, None
-
-    def deal(self, id: int) -> Transact:
-        return self.flopper.deal(id)

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -23,7 +23,6 @@ import time
 from contextlib import contextmanager
 from io import StringIO
 from mock import MagicMock
-from pymaker import Wad
 from web3 import Web3
 
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -114,7 +114,7 @@ class TransactionIgnoringTest:
         logging.debug("Finished ignoring async transactions")
 
     def start_ignoring_sync_transactions(self):
-        """ Mocks submission of a tx, prentending it happened """
+        """ Mocks submission of a tx, pretending it happened """
         self.original_tx_count = self.web3.eth.getTransactionCount
         self.original_get_receipt = Transact._get_receipt
         self.original_func = Transact._func

--- a/tests/manual_test_create_unsafe_vault.py
+++ b/tests/manual_test_create_unsafe_vault.py
@@ -100,7 +100,6 @@ def handle_returned_collateral():
 create_risky_vault()
 
 
-
 while True:
     time.sleep(6)
     urn = mcd.vat.urn(collateral.ilk, our_address)

--- a/tests/manual_test_create_unsafe_vault.py
+++ b/tests/manual_test_create_unsafe_vault.py
@@ -96,8 +96,7 @@ def handle_returned_collateral():
         logging.info(f"Attempting to exit {dai_balance} Dai")
         mcd.dai_adapter.exit(our_address, dai_balance).transact()
 
-
-create_risky_vault()
+# create_risky_vault()
 
 
 while True:

--- a/tests/manual_test_create_unsafe_vault.py
+++ b/tests/manual_test_create_unsafe_vault.py
@@ -96,7 +96,9 @@ def handle_returned_collateral():
         logging.info(f"Attempting to exit {dai_balance} Dai")
         mcd.dai_adapter.exit(our_address, dai_balance).transact()
 
-# create_risky_vault()
+
+create_risky_vault()
+
 
 
 while True:

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -150,12 +150,12 @@ class TestVatDaiTarget(TestVatDai):
 
 
 class TestEmptyVatOnExit(TestVatDai):
-    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_behavior):
+    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_on_shutdown: bool):
         assert isinstance(exit_dai_on_shutdown, bool)
-        assert isinstance(exit_gem_behavior, str) or exit_gem_behavior is None
+        assert isinstance(exit_gem_on_shutdown, bool)
 
         vat_dai_behavior = "" if exit_dai_on_shutdown else "--keep-dai-in-vat-on-exit"
-        vat_gem_behavior = "" if exit_gem_behavior else f"--return-gem-behavior {exit_gem_behavior}"
+        vat_gem_behavior = "" if exit_gem_on_shutdown else "--keep-gem-in-vat-on-exit"
 
         keeper = AuctionKeeper(args=args(f"--eth-from {self.keeper_address} "
                                          f"--type flip --ilk {self.collateral.ilk.name} "
@@ -173,7 +173,7 @@ class TestEmptyVatOnExit(TestVatDai):
 
     def test_do_not_empty(self):
         # given dai and gem in the vat
-        keeper = self.create_keeper(False, "NONE")
+        keeper = self.create_keeper(False, False)
         purchase_dai(Wad.from_number(153), self.keeper_address)
         assert self.get_dai_token_balance() >= Wad.from_number(153)
         assert self.mcd.dai_adapter.join(self.keeper_address, Wad.from_number(153)).transact(
@@ -202,7 +202,7 @@ class TestEmptyVatOnExit(TestVatDai):
         gem_vat_balance_before = self.get_gem_vat_balance()
 
         # when creating and shutting down the keeper
-        keeper = self.create_keeper(True, "none")
+        keeper = self.create_keeper(True, False)
         keeper.shutdown()
 
         # then ensure the dai was emptied
@@ -224,7 +224,7 @@ class TestEmptyVatOnExit(TestVatDai):
         dai_token_balance_before = self.get_dai_token_balance()
         dai_vat_balance_before = self.get_dai_vat_balance()
         # and creating and shutting down the keeper
-        keeper = self.create_keeper(False, "onexit")
+        keeper = self.create_keeper(False, True)
         keeper.shutdown()
 
         # then ensure dai was not emptied

--- a/tests/test_accounting.py
+++ b/tests/test_accounting.py
@@ -150,12 +150,12 @@ class TestVatDaiTarget(TestVatDai):
 
 
 class TestEmptyVatOnExit(TestVatDai):
-    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_on_shutdown: bool):
+    def create_keeper(self, exit_dai_on_shutdown: bool, exit_gem_behavior):
         assert isinstance(exit_dai_on_shutdown, bool)
-        assert isinstance(exit_gem_on_shutdown, bool)
+        assert isinstance(exit_gem_behavior, str) or exit_gem_behavior is None
 
         vat_dai_behavior = "" if exit_dai_on_shutdown else "--keep-dai-in-vat-on-exit"
-        vat_gem_behavior = "" if exit_gem_on_shutdown else "--keep-gem-in-vat-on-exit"
+        vat_gem_behavior = "" if exit_gem_behavior else f"--return-gem-behavior {exit_gem_behavior}"
 
         keeper = AuctionKeeper(args=args(f"--eth-from {self.keeper_address} "
                                          f"--type flip --ilk {self.collateral.ilk.name} "
@@ -173,7 +173,7 @@ class TestEmptyVatOnExit(TestVatDai):
 
     def test_do_not_empty(self):
         # given dai and gem in the vat
-        keeper = self.create_keeper(False, False)
+        keeper = self.create_keeper(False, "NONE")
         purchase_dai(Wad.from_number(153), self.keeper_address)
         assert self.get_dai_token_balance() >= Wad.from_number(153)
         assert self.mcd.dai_adapter.join(self.keeper_address, Wad.from_number(153)).transact(
@@ -202,7 +202,7 @@ class TestEmptyVatOnExit(TestVatDai):
         gem_vat_balance_before = self.get_gem_vat_balance()
 
         # when creating and shutting down the keeper
-        keeper = self.create_keeper(True, False)
+        keeper = self.create_keeper(True, "none")
         keeper.shutdown()
 
         # then ensure the dai was emptied
@@ -224,7 +224,7 @@ class TestEmptyVatOnExit(TestVatDai):
         dai_token_balance_before = self.get_dai_token_balance()
         dai_vat_balance_before = self.get_dai_vat_balance()
         # and creating and shutting down the keeper
-        keeper = self.create_keeper(False, True)
+        keeper = self.create_keeper(False, "onexit")
         keeper.shutdown()
 
         # then ensure dai was not emptied

--- a/tests/test_flap.py
+++ b/tests/test_flap.py
@@ -80,10 +80,13 @@ class TestAuctionKeeperFlapper(TransactionIgnoringTest):
         wait_for_other_threads()
 
         # then ensure another flap auction was kicked off
-        assert mcd.flapper.kicks() == kicks + 1
+        kick = mcd.flapper.kicks()
+        assert kick == kicks + 1
 
-        # clean up by letting the auction expire
-        time_travel_by(web3, mcd.flapper.tau() + 1)
+        # clean up by letting someone else bid and waiting until the auction ends
+        auction = self.flapper.bids(kick)
+        assert self.flapper.tend(kick, auction.lot, Wad.from_number(30)).transact(from_address=self.other_address)
+        time_travel_by(web3, mcd.flapper.ttl() + 1)
 
     def test_should_start_a_new_model_and_provide_it_with_info_on_auction_kick(self, kick):
         # given
@@ -196,7 +199,7 @@ class TestAuctionKeeperFlapper(TransactionIgnoringTest):
         time_travel_by(self.web3, self.flapper.ttl() + 1)
         assert self.flapper.deal(kick).transact()
 
-    def test_should_terminate_model_if_auction_expired_due_to_tau(self, kick):
+    def test_should_tick_if_auction_expired_due_to_tau(self, kick):
         # given
         (model, model_factory) = models(self.keeper, kick)
 
@@ -210,10 +213,20 @@ class TestAuctionKeeperFlapper(TransactionIgnoringTest):
         # when
         time_travel_by(self.web3, self.flapper.tau() + 1)
         # and
+        simulate_model_output(model=model, price=Wad.from_number(9.0))
+        # and
         self.keeper.check_all_auctions()
+        self.keeper.check_for_bids()
         wait_for_other_threads()
         # then
+        model.terminate.assert_not_called()
+        auction = self.flapper.bids(kick)
+        assert round(Wad(auction.lot) / auction.bid, 2) == round(Wad.from_number(9.0), 2)
+
+        # cleanup
+        time_travel_by(self.web3, self.flapper.ttl() + 1)
         model_factory.create_model.assert_called_once()
+        self.keeper.check_all_auctions()
         model.terminate.assert_called_once()
 
     def test_should_terminate_model_if_auction_expired_due_to_ttl_and_somebody_else_won_it(self, kick):

--- a/tests/test_flip.py
+++ b/tests/test_flip.py
@@ -302,7 +302,6 @@ class TestAuctionKeeperFlipper(TransactionIgnoringTest):
         time_travel_by(self.web3, flipper.ttl() + 1)
         self.keeper.check_all_auctions()
         model.terminate.assert_called_once()
-        assert flipper.deal(kick).transact()
 
     def test_should_terminate_model_if_auction_expired_due_to_ttl_and_somebody_else_won_it(self, kick, other_address):
         # given


### PR DESCRIPTION
The `Tick` mechanism enables the keeper to resurrect auctions which finished with no bids.  This change makes both `deal` and `tick` synchronous to avoid duplicate transactions.