### PR TITLE
Make bites synchronous, fix gas log message

### DIFF
--- a/auction_keeper/gas.py
+++ b/auction_keeper/gas.py
@@ -39,6 +39,8 @@ class UpdatableGasPrice(GasPrice):
 
 
 class DynamicGasPrice(NodeAwareGasPrice):
+    every_secs = 42
+
     def __init__(self, arguments, web3: Web3):
         assert isinstance(web3, Web3)
         self.gas_station = None
@@ -73,7 +75,7 @@ class DynamicGasPrice(NodeAwareGasPrice):
             initial_price = int(round(fast_price * self.initial_multiplier))
 
         return GeometricGasPrice(initial_price=initial_price,
-                                 every_secs=42,
+                                 every_secs=DynamicGasPrice.every_secs,
                                  coefficient=self.reactive_multiplier,
                                  max_price=self.gas_maximum).get_gas_price(time_elapsed)
 
@@ -86,8 +88,8 @@ class DynamicGasPrice(NodeAwareGasPrice):
             retval = f"Node gas price (currently {round(self.get_node_gas_price() / self.GWEI, 1)} Gwei, "\
                      "changes over time) "
 
-        retval += f"and will multiply by {self.reactive_multiplier} every 30s to a maximum of " \
-                  f"{round(self.gas_maximum / self.GWEI, 1)} Gwei"
+        retval += f"and will multiply by {self.reactive_multiplier} every {DynamicGasPrice.every_secs}s " \
+                  f"to a maximum of {round(self.gas_maximum / self.GWEI, 1)} Gwei"
         return retval
 
     def __repr__(self):

--- a/auction_keeper/main.py
+++ b/auction_keeper/main.py
@@ -407,7 +407,7 @@ class AuctionKeeper:
                                      f"min_lot={self.min_flip_lot}")
                     continue
 
-                self._run_future(self.cat.bite(ilk, urn).transact_async(gas_price=self.gas_price))
+                self.cat.bite(ilk, urn).transact(gas_price=self.gas_price)
 
         self.logger.info(f"Checked {len(urns)} urns in {(datetime.now()-started).seconds} seconds")
         # Cat.bite implicitly kicks off the flip auction; no further action needed.


### PR DESCRIPTION
A previous change increased the TX replacement interval from 30s to 42s, but the log message wasn't updated.  I made it a variable to correct this and prevent recurrence for future adjustments.

During periods of network congestion, the keeper would submit multiple bite transactions if gas price was insufficiently high to be mined by the subsequent bite check.  Improving the performance of the vault check exacerbated this behavior.  Since we want the keeper to remain stateless, the safe fix is to make `bite` transactions synchronous.  This will defer detection of new auctions until biting has completed, but users may configure their keeper not to bite, or adjust gas to speed up transactions.  This is better than wasting gas on TXes which will revert on chain.

Tested today on kovan by filling the `box` with 28 ETH-A bites.