### PR TITLE
don't assume vat.move destinations are urns of the same collateral type

### DIFF
--- a/auction_keeper/urn_history.py
+++ b/auction_keeper/urn_history.py
@@ -62,7 +62,7 @@ class ChainUrnHistoryProvider(UrnHistoryProvider):
         for log in logs:
             if isinstance(log, Vat.LogFrob):
                 urn_addresses.add(log.urn)
-            if isinstance(log, Vat.LogFork) or isinstance(log, Vat.LogMove):
+            if isinstance(log, Vat.LogFork):
                 urn_addresses.add(log.dst)
 
         # Update state of already-cached urns


### PR DESCRIPTION
`vat.move` operations move Dai from one vat address to another, and don't pertain to any specific collateral type.  As such, don't waste resources checking these vat addresses and counting them as urns.